### PR TITLE
made mpad url distributor-neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ The authorization flow depends on the `mpad.js` browser library. To show the log
 (authorization URL) and `data-element` (login button ID)
 
 ```
-<script src="https://dd.cdn.mpin.io/mpad/mpad.js" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
+<script src="<<Insert correct mpad url here>>" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
 ```
+Please refer to your distributor-specific documentation to find the correct url for the mpad.js script src
 
 # Sample app
 

--- a/templates/main.php
+++ b/templates/main.php
@@ -78,8 +78,9 @@
         </div>
     <?php } ?>
 </div>
+<!--Please refer to your distributor-specific documentation to find the correct url for the mpad.js script src-->
 <?php if (isset($authURL)) { ?>
-    <script src="https://dd.cdn.mpin.io/mpad/mpad.js" data-authurl="<?= $authURL ?>" data-element="btmpin"></script>
+    <script src="<<Insert correct mpad url here>>" data-authurl="<?= $authURL ?>" data-element="btmpin"></script>
 <?php } ?>
 </body>
 </html>


### PR DESCRIPTION
This is to make the SDK repos distributor-neutral.

The instructions for the correct mpad.js url are found in the devdocs for each distributor.